### PR TITLE
docs: referenced-content collections (ord-fs/json + . default entry), BSV-21 token members, SIGMA authorship

### DIFF
--- a/adding-metadata/collectionitem-subtype.md
+++ b/adding-metadata/collectionitem-subtype.md
@@ -49,3 +49,50 @@ Output 1:
   ]
 }
 ```
+
+## Fungible (BSV-21) collection members
+
+A `collectionItem` is not required to be an image inscription. A BSV-21
+`deploy+mint` or `deploy+auth` output (content type `application/bsv-20`, see
+[BSV-21](../fungible-tokens/bsv-21.md)) may itself carry `collectionItem`
+metadata as a MAP suffix appended after its `bsv-20` JSON payload, exactly as
+any other ordinal does. The collection membership lives entirely in MAP — the
+`bsv-20` JSON is unchanged and carries no collection fields.
+
+In this case:
+
+- The **member is the token's deploy/genesis outpoint** (`tokenId`, i.e.
+  `<txid>_0`), not any individual held or transferred unit. Metadata inherits to
+  holders by resolving `tokenId` back to its deploy outpoint — the same way
+  `sym`/`dec`/`icon` already inherit per the BSV-21 spec. One token type is one
+  collection member. An application may treat a nonzero balance as ownership
+  or access; BSV-21 itself proves the balance but does not enforce product rights.
+- `mintNumber` and `rank` do not apply to a fungible member and should be
+  omitted.
+- `traits` / `rarityLabel`, if present, describe the token type as a whole
+  rather than an edition or serial position.
+- The token's own `icon` field (an inscription-origin or B-protocol-file
+  outpoint) may serve as the item's preview image in place of a separate
+  `previewUrl` / attachment.
+- Canonical membership is `subTypeData.collectionId` plus an authorship
+  signature whose signer matches the collection root. Use **SIGMA** — its prefix
+  commits to a transaction input, so the signature cannot be replayed onto
+  another item (legacy AIP-signed members remain valid). When `collectionId` is
+  an absolute outpoint, the ordinal `parent` field (field 3) may duplicate it as
+  a navigation hint; it is not required, and a same-transaction `_N` reference
+  cannot use it.
+
+### Supply model
+
+The BSV-21 supply model the member uses is a product decision, not a collection
+concern:
+
+- **Fixed supply** (`deploy+mint`) — the entire, immutable supply is created at
+  deploy. Fits capped editions: e.g. an album collection where each track is a
+  member token with a set number of tradeable units, one unit granting the right
+  to play that track.
+- **Auth tokens** (`deploy+auth` then `mint`) — no initial supply; an auth UTXO
+  grants ongoing minting. Fits access passes and any mint-over-time model. Only
+  the holder of the auth UTXO can mint more, so a distributor keeps that key on
+  the server and mints one unit per sale (mint-on-buy). The collection creator
+  and the auth holder are typically the same key.

--- a/adding-metadata/signing.md
+++ b/adding-metadata/signing.md
@@ -24,3 +24,29 @@ You can not only use AIP signatures to prove a particular identity created an in
 
 ## Validating Collections
 
+A collection and its items should carry an authorship signature identifying the
+collection author, so membership can be validated: an item is a genuine member of
+collection `X` only if its `subTypeData.collectionId` points at `X` **and** its
+authorship signer matches the collection root.
+
+### SIGMA (recommended)
+
+Prefer **SIGMA** for 1-sat ordinal authorship (collection roots and items). The
+SIGMA prefix commits to a specific transaction input, so the signature is
+**replay-resistant** — it cannot be lifted from one item and re-used to forge
+membership on another, which the AIP `[-1]` whole-output form does not prevent.
+Signing follows output type: a signed 1-sat ordinal uses SIGMA; a signed 0-sat
+`B` output uses AIP.
+
+Legacy AIP `[-1]`-signed collections and items remain valid; indexers accept
+either protocol when matching a member's signer against the collection root.
+
+### Owner-follows authority
+
+The collection root is an owned 1-sat ordinal whose metadata may be updated by
+spending and re-inscribing it (resolve the latest state with `{root}:-1`).
+Membership and metadata-update authority follow the current owner: a member is
+authoritative if its signer matched the root's controlling key **as of the
+member's inscription**, so transferring the root delegates authority without
+retroactively invalidating members already minted under the prior owner.
+

--- a/reference-inscriptions.md
+++ b/reference-inscriptions.md
@@ -37,3 +37,69 @@ You can also reference many files in a single text/uri-list inscription:
 ```
 
 In this example we can make the contents of a webpage and all of its dependencies available as a single package.
+
+### Referencing shared content (collections & large mints)
+
+A reference points at content that already exists on-chain, so many inscriptions
+can share one payload instead of each re-inscribing it. For a collection — or any
+large mint — inscribe the artwork **once** and have every item reference that
+outpoint. A 10,000-item drop then costs one image plus a tiny reference per item,
+not 10,000 copies, and the same holds when items are minted on demand.
+
+Produce a referenced item as an **`ord-fs/json` directory**, resolved by
+[OrdFS](ordfs.md). Its content-type honestly signals that the content must be
+resolved, and it fails safe — a consumer that doesn't resolve it sees a
+non-media type rather than mis-rendering a pointer as image bytes.
+
+- **Single shared or unique image** — a one-entry directory using the `.`
+  default-entry key. OrdFS serves the `.` entry in place at the item's own URL
+  (see [Directories](ordfs.md#directories)), so no interior filename is needed:
+
+  ```json
+  { ".": "<imageOutpoint>" }
+  ```
+
+- **Multi-leaf item** — add named leaves for per-item metadata or attachments
+  alongside the default entry:
+
+  ```json
+  { ".": "<imageOutpoint>", "meta.json": "_1" }
+  ```
+
+The `<imageOutpoint>` pointer may be a same-transaction relative `_N` or an
+absolute `<txid>_<vout>` (cross-tx, e.g. mint-on-demand). A resolver also
+**accepts** a `text/uri-list` item (RFC 2483) for interoperability with tools
+that emit it, but new items are produced as `ord-fs/json`. (An earlier
+`ref=ordfs` media-type-parameter form was considered and dropped: declaring a
+real image type over a pointer body mis-renders in any consumer that reads the
+inscription without stripping the parameter.)
+
+#### Tradeable items, shared content
+
+Keep the collection and item MAP envelopes unchanged:
+
+- **Collection** — remains the classic `image/*` MAP `collection` ordinal.
+- **Item** — remains a tradeable 1-sat MAP `collectionItem` ordinal with the
+  same `collectionId`, mint, rarity, trait, and attachment fields. Only its
+  inscription content changes from image bytes to a reference.
+- **Referenced content** — can be an existing inscription or a 0-sat bitcom
+  `B` output. Directory manifests may point to shared or item-specific content
+  without changing collection membership.
+
+The collection and item carry an authorship signature whose signer identifies
+the collection author. Use **SIGMA** for the 1-sat ordinal (its prefix commits
+to a transaction input, so the signature is replay-resistant and cannot be
+lifted onto another item); legacy AIP-signed collections remain valid. Signing
+follows output type: a signed 1-sat ordinal uses SIGMA and a signed 0-sat `B`
+output uses AIP; immutable leaves may also be unsigned.
+
+#### Resolution notes
+
+- A referenced or leaf output resolves only if its transaction is in the serving
+  OrdFS instance's store (same [scope rules](ordfs.md#scope-of-a-deployment)).
+- Leaf content must be an inscription envelope or a **bitcom `B`** output; a raw
+  `OP_RETURN` pushdata that is not `B` carries no servable content type.
+- `{outpoint}:-1` "latest" applies to a **1-sat** ordinal — it follows the
+  transfer chain. 0-sat B leaves are immutable and resolve at their exact
+  outpoint, and directory traversal resolves leaves pinned; request a nested
+  manifest directly with `:-1` to resolve its tip.


### PR DESCRIPTION
Documents the referenced-content collection pattern now that the OrdFS `.` default-entry has landed.

## What this adds
- **`reference-inscriptions.md`** — a "Referencing shared content (collections & large mints)" section: produce a referenced item as an **`ord-fs/json` directory** with a `.` default-entry (`{ ".": "<imageOutpoint>" }`), served in place. Multi-leaf items add named leaves. `text/uri-list` is accepted for interop; a `ref=ordfs` media-type-parameter form was considered and dropped (it declares a real image type over a pointer body and mis-renders in any consumer that reads the inscription without stripping the parameter).
- **`adding-metadata/collectionitem-subtype.md`** — a "Fungible (BSV-21) collection members" subsection: a `bsv-20` deploy may carry standard `collectionItem` MAP (membership in MAP, JSON unchanged); the member is the deploy/genesis outpoint; `mintNumber`/`rank` omitted; `icon` is the preview; fixed vs auth supply models.
- **`adding-metadata/signing.md`** — fills in "Validating Collections": prefer **SIGMA** for 1-sat ordinal authorship (its prefix commits to a tx input → replay-resistant, so a membership signature can't be forged onto another item); legacy AIP `[-1]` stays valid; owner-follows authority (metadata updatable via `{root}:-1`, membership validated point-in-time).

No existing fields or envelopes change — these are additive.